### PR TITLE
Update v1.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.0
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [ --fix,  --show-fixes ]
   - id: ruff-format
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Tests](https://github.com/samarthmistry/opti-extensions/actions/workflows/tests.yaml/badge.svg)](https://github.com/samarthmistry/opti-extensions/blob/main/.github/workflows/tests.yaml)
 [![Coverage](https://raw.githubusercontent.com/samarthmistry/opti-extensions/main/coverage.svg)](https://github.com/samarthmistry/opti-extensions/tree/main/tests/unit_tests)
 
-A collection of custom data structures and user-friendly functions for mathematical optimization modeling with [docplex](https://ibmdecisionoptimization.github.io/docplex-doc), [gurobipy](https://docs.gurobi.com/projects/optimizer/en/current/reference/python.html), and [xpress](https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/python/HTML).
+A collection of custom data structures and user-friendly functions for mathematical optimization modeling with [DOcplex](https://ibmdecisionoptimization.github.io/docplex-doc), [gurobipy](https://docs.gurobi.com/projects/optimizer/en/current/reference/python.html), and [Xpress](https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/python/HTML).
 
 Features
 --------
@@ -16,7 +16,7 @@ Features
 * **Specialized data structures**: For defining index-sets, parameters, and decision variables enabling concise and high-performance algebraic modeling — compatible across different solver APIs.
 * **Easy access to additional CPLEX functionality**: Like [tuning tool](https://www.ibm.com/docs/en/icos/latest?topic=programmingconsiderations-tuning-tool), [runseeds](https://www.ibm.com/docs/en/icos/latest?topic=cplex-evaluating-variability), [displaying problem statistics](https://www.ibm.com/docs/en/icos/latest?topic=problem-displaying-statistics), and [displaying solution quality statistics](https://www.ibm.com/docs/en/icos/latest?topic=cplex-evaluating-solution-quality) — not directly available in DOcplex.
 * **Type-complete interface**: Enables static type checking and intelligent auto-completion suggestions with modern IDEs — reducing type errors and improving development speed.
-* **Robust codebase**: 100% coverage spanning 2500+ test cases and fully type-checked with mypy under [strict mode](https://mypy.readthedocs.io/en/stable/getting_started.html#strict-mode-and-configuration).
+* **Robust codebase**: 100% coverage spanning 2600+ test cases and fully type-checked with mypy under [strict mode](https://mypy.readthedocs.io/en/stable/getting_started.html#strict-mode-and-configuration).
 
 Links
 -----

--- a/docs/source/api_reference/docplex_variables.rst
+++ b/docs/source/api_reference/docplex_variables.rst
@@ -40,6 +40,7 @@ Numerical operations
 .. autosummary::
 
    VarDict1D.sum
+   VarDict1D.sum_squares
 
 Mapping operations
 ------------------
@@ -79,6 +80,7 @@ Numerical operations
 .. autosummary::
 
    VarDictND.sum
+   VarDictND.sum_squares
 
 Mapping operations
 ------------------

--- a/docs/source/api_reference/docplex_variables.rst
+++ b/docs/source/api_reference/docplex_variables.rst
@@ -41,6 +41,14 @@ Numerical operations
 
    VarDict1D.sum
    VarDict1D.sum_squares
+   VarDict1D.dot
+
+The ``@`` operator
+------------------
+
+The matrix multiplication operator ``@`` can be used instead of the `dot`
+method. Both ``ParamDict1D @ VarDict1D`` and ``VarDict1D @ ParamDict1D``
+will produce the same result as ``VarDict1D.dot(ParamDict1D)``.
 
 Mapping operations
 ------------------
@@ -81,6 +89,14 @@ Numerical operations
 
    VarDictND.sum
    VarDictND.sum_squares
+   VarDictND.dot
+
+The ``@`` operator
+------------------
+
+The matrix multiplication operator ``@`` can be used instead of the `dot`
+method. Both ``ParamDictND @ VarDictND`` and ``VarDictND @ ParamDictND``
+will produce the same result as ``VarDictND.dot(ParamDictND)``.
 
 Mapping operations
 ------------------

--- a/docs/source/api_reference/gurobipy_variables.rst
+++ b/docs/source/api_reference/gurobipy_variables.rst
@@ -40,6 +40,14 @@ Numerical operations
 
    VarDict1D.sum
    VarDict1D.sum_squares
+   VarDict1D.dot
+
+The ``@`` operator
+------------------
+
+The matrix multiplication operator ``@`` can be used instead of the `dot`
+method. Both ``ParamDict1D @ VarDict1D`` and ``VarDict1D @ ParamDict1D``
+will produce the same result as ``VarDict1D.dot(ParamDict1D)``.
 
 Mapping operations
 ------------------
@@ -80,6 +88,14 @@ Numerical operations
 
    VarDictND.sum
    VarDictND.sum_squares
+   VarDictND.dot
+
+The ``@`` operator
+------------------
+
+The matrix multiplication operator ``@`` can be used instead of the `dot`
+method. Both ``ParamDictND @ VarDictND`` and ``VarDictND @ ParamDictND``
+will produce the same result as ``VarDictND.dot(ParamDictND)``.
 
 Mapping operations
 ------------------

--- a/docs/source/api_reference/gurobipy_variables.rst
+++ b/docs/source/api_reference/gurobipy_variables.rst
@@ -39,6 +39,7 @@ Numerical operations
 .. autosummary::
 
    VarDict1D.sum
+   VarDict1D.sum_squares
 
 Mapping operations
 ------------------
@@ -78,6 +79,7 @@ Numerical operations
 .. autosummary::
 
    VarDictND.sum
+   VarDictND.sum_squares
 
 Mapping operations
 ------------------

--- a/docs/source/api_reference/xpress_variables.rst
+++ b/docs/source/api_reference/xpress_variables.rst
@@ -40,6 +40,14 @@ Numerical operations
 
    VarDict1D.sum
    VarDict1D.sum_squares
+   VarDict1D.dot
+
+The ``@`` operator
+------------------
+
+The matrix multiplication operator ``@`` can be used instead of the `dot`
+method. Both ``ParamDict1D @ VarDict1D`` and ``VarDict1D @ ParamDict1D``
+will produce the same result as ``VarDict1D.dot(ParamDict1D)``.
 
 Mapping operations
 ------------------
@@ -80,6 +88,14 @@ Numerical operations
 
    VarDictND.sum
    VarDictND.sum_squares
+   VarDictND.dot
+
+The ``@`` operator
+------------------
+
+The matrix multiplication operator ``@`` can be used instead of the `dot`
+method. Both ``ParamDictND @ VarDictND`` and ``VarDictND @ ParamDictND``
+will produce the same result as ``VarDictND.dot(ParamDictND)``.
 
 Mapping operations
 ------------------

--- a/docs/source/api_reference/xpress_variables.rst
+++ b/docs/source/api_reference/xpress_variables.rst
@@ -39,6 +39,7 @@ Numerical operations
 .. autosummary::
 
    VarDict1D.sum
+   VarDict1D.sum_squares
 
 Mapping operations
 ------------------
@@ -78,6 +79,7 @@ Numerical operations
 .. autosummary::
 
    VarDictND.sum
+   VarDictND.sum_squares
 
 Mapping operations
 ------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -188,7 +188,7 @@ def autodoc_override_docstring(app, what, name, obj, options, lines):
                 func = 'addVariables'
             lines[:] = [
                 f'This class is not meant to be instantiated; {obj.__name__} is built through the '
-                f'`{module}.{func}` function.',
+                f'``{module}.{func}`` function.',
             ]
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Features
 * **Type-complete interface**: Enables static type checking and intelligent
   auto-completion suggestions with modern IDEs — reducing type errors and
   improving development speed.
-* **Robust codebase**: 100% coverage spanning 2500+ test cases and fully
+* **Robust codebase**: 100% coverage spanning 2600+ test cases and fully
   type-checked with mypy under `strict mode <https://mypy.readthedocs.io/en/
   stable/getting_started.html#strict-mode-and-configuration>`_.
 

--- a/examples/data_structures_overview/example_indexsets.py
+++ b/examples/data_structures_overview/example_indexsets.py
@@ -17,13 +17,13 @@ sets for this problem with these data structures.
 # %%
 
 # Let's import the classes defining IndexSets
+from opti_extensions import IndexSet1D, IndexSetND
+
 # To show fail cases
 import traceback
 
 # We'll also work with dataframes and series
 import pandas as pd
-
-from opti_extensions import IndexSet1D, IndexSetND
 
 # %%
 # IndexSet1D

--- a/examples/data_structures_overview/example_paramdicts.py
+++ b/examples/data_structures_overview/example_paramdicts.py
@@ -16,13 +16,13 @@ parameters for this problem with these data structures.
 # %%
 
 # Let's import the classes defining IndexSets & ParamDicts
+from opti_extensions import ParamDict1D, ParamDictND
+
 # To show fail cases
 import traceback
 
 # We'll also work with dataframes and series
 import pandas as pd
-
-from opti_extensions import ParamDict1D, ParamDictND
 
 # %%
 # ParamDict1D

--- a/examples/data_structures_overview/example_vardicts.py
+++ b/examples/data_structures_overview/example_vardicts.py
@@ -126,10 +126,11 @@ print({j: select_fac.lookup(j) for j in ('F1', 'F2', 'F99')})
 # ^^^^^^^^^^^^^^^^^^^^
 
 # %%
-# It has a special method for directly summing up variables.
+# It has special methods to directly sum all variables and sum squares of all variables.
 
 # %%
 print(select_fac.sum())
+print(select_fac.sum_squares())
 
 # %%
 # VarDictND
@@ -258,18 +259,30 @@ print('With if check:', [val for elem, val in dem_alloc.items() if elem[1] == 1]
 # ^^^^^^^^^^^^^^^^^^^^
 
 # %%
-# It has a special method for directly summing up all or a subset of variables.
+# It has special methods to directly sum all (or a subset of) variables and sum squares of all (or a
+# subset of) variables
 
 # %%
 
-# Sum all variables of dem_alloc
+# Sum all dem_alloc variables
 print(dem_alloc.sum())
 
 # %%
 
-# Sum over a subset of variables, that have the value 'F1' in the first dimension and any value in
-# the second dimension of dem_alloc, based on wildcard pattern
+# Sum a subset of dem_alloc variables, that have the value 'F1' in the first dimension and any value in
+# the second dimension, based on wildcard pattern
 print(dem_alloc.sum('F1', '*'))
+
+# %%
+
+# Sum squares of all dem_alloc variables
+print(dem_alloc.sum_squares())
+
+# %%
+
+# Sum squares of a subset of dem_alloc variables, that have the value 'F1' in the first dimension and any
+# value in the second dimension, based on wildcard pattern
+print(dem_alloc.sum_squares('F1', '*'))
 
 # %%
 # Not only does it provide a cleaner syntax, but it is also very performant because of an internal

--- a/examples/data_structures_overview/example_vardicts.py
+++ b/examples/data_structures_overview/example_vardicts.py
@@ -11,12 +11,18 @@ are immutable subclasses of Python's dict with some additional functionality.
 
 Suppose we want build a model to solve the facility location problem. We'll define the
 variables for this problem with these data structures.
+
+.. note::
+
+    We'll be using DOcplex here, but the same approach will work for gurobipy and Xpress.
 """
 
 # %%
 
-# We'll work with DOcplex here, but the same approach applies to gurobipy and Xpress
-# To show fail cases
+# Let's import the classes defining IndexSets, and the function that adds variables based on
+# IndexSets and returns VarDicts
+from opti_extensions import IndexSet1D, IndexSetND
+from opti_extensions.docplex import add_variables
 
 # We'll also work with dataframes and series
 import pandas as pd
@@ -24,9 +30,6 @@ import pandas as pd
 # %%
 # Let's instantiate a DOcplex model
 from docplex.mp.model import Model
-
-from opti_extensions import IndexSet1D, IndexSetND
-from opti_extensions.docplex import add_variables
 
 mdl = Model()
 

--- a/examples/data_structures_overview/example_vardicts.py
+++ b/examples/data_structures_overview/example_vardicts.py
@@ -126,7 +126,41 @@ print({j: select_fac.lookup(j) for j in ('F1', 'F2', 'F99')})
 # ^^^^^^^^^^^^^^^^^^^^
 
 # %%
-# It has special methods to directly sum all variables and sum squares of all variables.
+# It has special methods for numerical operations: `sum`, `sum_squares`, and `dot` / ``@`` operator.
+
+# %%
+# `dot` method / ``@`` operator
+# """""""""""""""""""""""""""""
+
+# %%
+# To sum the products of variables with corresponding coef from ParamDict1D. Assumes the coef to be
+# zero if not found in the ParamDict1D.
+
+# %%
+
+# Define COST parameter
+from opti_extensions import ParamDict1D
+
+FIXED_COST = ParamDict1D(
+    {'F1': 10000, 'F2': 20000},
+    #   does NOT include: 'F3' ^^^^
+)
+
+# Compute dot product of COST parameter with dem_alloc variables
+print(select_fac.dot(FIXED_COST))
+
+# %%
+
+# Alternative syntax with the `@` operator
+print(FIXED_COST @ select_fac)
+print(select_fac @ FIXED_COST)
+
+# %%
+# `sum` & `sum_squares` methods
+# """""""""""""""""""""""""""""
+
+# %%
+# To directly sum all or a subset of variables, and sum squares of all or a subset of variables.
 
 # %%
 print(select_fac.sum())
@@ -259,8 +293,41 @@ print('With if check:', [val for elem, val in dem_alloc.items() if elem[1] == 1]
 # ^^^^^^^^^^^^^^^^^^^^
 
 # %%
-# It has special methods to directly sum all (or a subset of) variables and sum squares of all (or a
-# subset of) variables
+# It has special methods for numerical operations: `sum`, `sum_squares`, and `dot` / ``@`` operator.
+
+# %%
+# `dot` method / ``@`` operator
+# """""""""""""""""""""""""""""
+
+# %%
+# To sum the products of variables with corresponding coef from ParamDictND. Assumes the coef to be
+# zero if not found in the ParamDictND.
+
+# %%
+
+# Define COST parameter
+from opti_extensions import ParamDictND
+
+COST = ParamDictND(
+    {('F1', 1): 197, ('F1', 2): 345, ('F2', 1): 99, ('F2', 2): 270, ('F3', 1): 205},
+    #                                                   does NOT include: ('F3', 2) ^^^^
+)
+
+# Compute dot product of COST parameter with dem_alloc variables
+print(dem_alloc.dot(COST))
+
+# %%
+
+# Alternative syntax with the `@` operator
+print(COST @ dem_alloc)
+print(dem_alloc @ COST)
+
+# %%
+# `sum` & `sum_squares` methods
+# """""""""""""""""""""""""""""
+
+# %%
+# To directly sum all or a subset of variables, and sum squares of all or a subset of variables.
 
 # %%
 

--- a/examples/model_building/example_build_diet.py
+++ b/examples/model_building/example_build_diet.py
@@ -192,7 +192,7 @@ buy = add_variables(model, indexset=FOOD, vartype='continuous', lb=f_min, ub=f_m
 
 # Set objective
 model.minimize(
-    model.sum(cost[j] * buy[j] for j in FOOD)
+    cost @ buy
 )
 
 # Add constraints
@@ -235,8 +235,8 @@ buy = addVars(model, indexset=FOOD, lb=f_min, ub=f_max, vtype=GRB.CONTINUOUS, na
 
 # Set objective
 model.setObjective(
-    quicksum(cost[j] * buy[j] for j in FOOD),
-    sense=GRB.MINIMIZE
+    cost @ buy,
+    sense=GRB.MINIMIZE,
 )
 
 # Add constraints
@@ -273,8 +273,8 @@ buy = addVariables(prob, indexset=FOOD, vartype=xp.continuous, lb=f_min, ub=f_ma
 
 # Set objective
 prob.setObjective(
-    xp.Sum(cost[j] * buy[j] for j in FOOD),
-    sense=xp.minimize
+    cost @ buy,
+    sense=xp.minimize,
 )
 
 # Add constraints

--- a/examples/model_building/example_build_diet.py
+++ b/examples/model_building/example_build_diet.py
@@ -187,33 +187,31 @@ from opti_extensions.docplex import add_variables, solve
 model = Model(name='diet')
 
 # Add variables
-# Use `add_variables` from opti-extensions instead of `model.continuous_var_dict`
 buy = add_variables(model, indexset=FOOD, vartype='continuous', lb=f_min, ub=f_max, name='BUY-QTY')
+# Instead of:
+# buy = model.continuous_var_dict(FOOD, lb=[f_min[j] for j in FOOD], ub=[f_max[j] for j in FOOD], name='BUY-QTY')
 
 # Set objective
 model.minimize(
     cost @ buy
+    # Instead of:
+    # model.sum(cost[j] * buy[j] for j in FOOD)
 )
 
 # Add constraints
 model.add_constraints_(
-    (
-        model.sum(amt[i, j] * buy[j] for j in FOOD) >= n_min[i],
-        f'min-nutr-reqd_{i}',
-    )
+    model.sum(amt[i, j] * buy[j] for j in FOOD) >= n_min[i]
     for i in NUTR
 )
 model.add_constraints_(
-    (
-        model.sum(amt[i, j] * buy[j] for j in FOOD) <= n_max[i],
-        f'max-nutr-allwd_{i}',
-    )
+    model.sum(amt[i, j] * buy[j] for j in FOOD) <= n_max[i]
     for i in NUTR
 )
 
 # Solve with additional logging output for problem and solution statistics
-# Use `solve` from opti-extensions instead of `model.solve`
 sol = solve(model, log_output=True)
+# Instead of:
+# sol = model.solve(log_output=True)
 
 # %%
 sol.display(print_zeros=False)
@@ -230,23 +228,24 @@ from opti_extensions.gurobipy import addVars
 model = Model(name='diet')
 
 # Add variables
-# Use `addVars` from opti-extensions instead of `model.addVars`
 buy = addVars(model, indexset=FOOD, lb=f_min, ub=f_max, vtype=GRB.CONTINUOUS, name='BUY-QTY')
+# Instead of:
+# buy = model.addVars(FOOD, lb=f_min, ub=f_max, vtype=GRB.CONTINUOUS, name='BUY-QTY')
 
 # Set objective
 model.setObjective(
     cost @ buy,
+    # Instead of:
+    # quicksum(cost[j] * buy[j] for j in FOOD)
     sense=GRB.MINIMIZE,
 )
 
 # Add constraints
 model.addConstrs(
-    (quicksum(amt[i, j] * buy[j] for j in FOOD) >= n_min[i] for i in NUTR),
-    name='min-nutr-reqd',
+    quicksum(amt[i, j] * buy[j] for j in FOOD) >= n_min[i] for i in NUTR
 )
 model.addConstrs(
-    (quicksum(amt[i, j] * buy[j] for j in FOOD) <= n_max[i] for i in NUTR),
-    name='max-nutr-allwd',
+    quicksum(amt[i, j] * buy[j] for j in FOOD) <= n_max[i] for i in NUTR
 )
 
 # Solve
@@ -268,12 +267,18 @@ from opti_extensions.xpress import addVariables
 prob = xp.problem(name='diet')
 
 # Add variables
-# Use `addVariables` from opti-extensions instead of `prob.addVariables`
 buy = addVariables(prob, indexset=FOOD, vartype=xp.continuous, lb=f_min, ub=f_max, name='BUY-QTY')
+# Instead of:
+# buy = {
+#     j: prob.addVariable(name=f'x({j})', ub=f_min.get(j, 0), ub=f_max.get(j, xp.infinity), vartype=xp.continuous)
+#     for j in FOOD
+# }
 
 # Set objective
 prob.setObjective(
     cost @ buy,
+    # Instead of:
+    # xp.Sum(cost[j] * buy[j] for j in FOOD)
     sense=xp.minimize,
 )
 

--- a/examples/model_building/example_build_multicommodity.py
+++ b/examples/model_building/example_build_multicommodity.py
@@ -225,14 +225,7 @@ use = add_variables(
 
 # Set objective
 model.minimize(
-    model.sum(
-        vcost[i, j, p] * trans[i, j, p]
-        for i in ORIG for j in DEST for p in PROD
-    )
-    + model.sum(
-        fcost[i, j] * use[i, j]
-        for i in ORIG for j in DEST
-    )
+    vcost @ trans + fcost @ use
 )
 
 # Add constraints
@@ -269,7 +262,7 @@ sol.display(print_zeros=False)
 # Implement with gurobipy
 # -----------------------
 
-from gurobipy import GRB, Model, quicksum
+from gurobipy import GRB, Model
 
 from opti_extensions.gurobipy import addVars
 
@@ -293,14 +286,7 @@ use = addVars(
 
 # Set objective
 model.setObjective(
-    quicksum(
-        vcost[i, j, p] * trans[i, j, p]
-        for i in ORIG for j in DEST for p in PROD
-    )
-    + quicksum(
-        fcost[i, j] * use[i, j]
-        for i in ORIG for j in DEST
-    ),
+    vcost @ trans + fcost @ use,
     sense=GRB.MINIMIZE,
 )
 
@@ -361,14 +347,7 @@ use = addVariables(
 
 # Set objective
 prob.setObjective(
-    xp.Sum(
-        vcost[i, j, p] * trans[i, j, p]
-        for i in ORIG for j in DEST for p in PROD
-    )
-    + xp.Sum(
-        fcost[i, j] * use[i, j]
-        for i in ORIG for j in DEST
-    ),
+    vcost @ trans + fcost @ use,
     sense=xp.minimize,
 )
 

--- a/examples/model_building/example_build_p_median.py
+++ b/examples/model_building/example_build_p_median.py
@@ -138,7 +138,7 @@ y = add_variables(model, indexset=FAC, vartype='binary', name='y')
 
 # Set objective
 model.minimize(
-    model.sum(cost[i, j] * x[i, j] for i in CUST for j in FAC)
+    cost @ x
 )
 
 # Add constraints
@@ -165,7 +165,7 @@ sol.display(print_zeros=False)
 # Implement with gurobipy
 # -----------------------
 
-from gurobipy import GRB, Model, quicksum
+from gurobipy import GRB, Model
 
 from opti_extensions.gurobipy import addVars
 
@@ -179,8 +179,8 @@ y = addVars(model, indexset=FAC, vtype=GRB.BINARY, name='y')
 
 # Set objective
 model.setObjective(
-    quicksum(cost[i, j] * x[i, j] for i in CUST for j in FAC),
-    sense=GRB.MINIMIZE
+    cost @ x,
+    sense=GRB.MINIMIZE,
 )
 
 # Add constraints
@@ -221,8 +221,8 @@ y = addVariables(prob, indexset=FAC, vartype=xp.binary, name='y')
 
 # Set objective
 prob.setObjective(
-    xp.Sum(cost[i, j] * x[i, j] for i in CUST for j in FAC),
-    sense=xp.minimize
+    cost @ x,
+    sense=xp.minimize,
 )
 
 # Add constraints

--- a/examples/model_building/example_build_p_median.py
+++ b/examples/model_building/example_build_p_median.py
@@ -132,18 +132,25 @@ from opti_extensions.docplex import add_variables, solve
 model = Model(name='p-median')
 
 # Add variables
-# Use `add_variables` from opti-extensions instead of `model.binary_var_dict`
 x = add_variables(model, indexset=CUST_x_FAC, vartype='binary', name='x')
+# Instead of:
+# x = model.binary_var_dict(CUST_x_FAC, name='x')
 y = add_variables(model, indexset=FAC, vartype='binary', name='y')
+# Instead of:
+# y = model.binary_var_dict(FAC, name='y')
 
 # Set objective
 model.minimize(
     cost @ x
+    # Instead of:
+    # model.sum(cost[i, j] * x[i, j] for i in CUST for j in FAC)
 )
 
 # Add constraints
 model.add_constraints_(
     x.sum(i, '*') == 1
+    # Instead of:
+    # model.sum(x[i, j] for j in FAC) == 1
     for i in CUST
 )
 model.add_constraints_(
@@ -152,11 +159,14 @@ model.add_constraints_(
 )
 model.add_constraint_(
     y.sum() == p
+    # Instead of:
+    # model.sum(y[j] for j in FAC) == p
 )
 
 # Solve with additional logging output for problem and solution statistics
-# Use `solve` from opti-extensions instead of `model.solve`
 sol = solve(model, log_output=True)
+# Instead of:
+# sol = model.solve(log_output=True)
 
 # %%
 sol.display(print_zeros=False)
@@ -173,19 +183,26 @@ from opti_extensions.gurobipy import addVars
 model = Model(name='p-median')
 
 # Add variables
-# Use `addVars` from opti-extensions instead of `model.addVars`
 x = addVars(model, indexset=CUST_x_FAC, vtype=GRB.BINARY, name='x')
+# Instead of:
+# x = model.addVars(CUST_x_FAC, vtype=GRB.BINARY, name='x')
 y = addVars(model, indexset=FAC, vtype=GRB.BINARY, name='y')
+# Instead of:
+# y = model.addVars(FAC, vtype=GRB.BINARY, name='y')
 
 # Set objective
 model.setObjective(
     cost @ x,
+    # Instead of:
+    # quicksum(cost[i, j] * x[i, j] for i in CUST for j in FAC)
     sense=GRB.MINIMIZE,
 )
 
 # Add constraints
 model.addConstrs(
     x.sum(i, '*') == 1
+    # Instead of:
+    # quicksum(x[i, j] for j in FAC) == 1
     for i in CUST
 )
 model.addConstrs(
@@ -194,6 +211,8 @@ model.addConstrs(
 )
 model.addConstr(
     y.sum() == p
+    # Instead of:
+    # quicksum(y[j] for j in FAC) == p
 )
 
 # Solve
@@ -215,19 +234,26 @@ from opti_extensions.xpress import addVariables
 prob = xp.problem(name='p-median')
 
 # Add variables
-# Use `addVariables` from opti-extensions instead of `prob.addVariables`
 x = addVariables(prob, indexset=CUST_x_FAC, vartype=xp.binary, name='x')
+# Instead of:
+# x = prob.addVariables(CUST_x_FAC, vartype=xp.binary, name='x')
 y = addVariables(prob, indexset=FAC, vartype=xp.binary, name='y')
+# Instead of:
+# y = prob.addVariables(FAC, vartype=xp.binary, name='y')
 
 # Set objective
 prob.setObjective(
     cost @ x,
+    # Instead of:
+    # xp.Sum(cost[i, j] * x[i, j] for i in CUST for j in FAC)
     sense=xp.minimize,
 )
 
 # Add constraints
 prob.addConstraint(
     x.sum(i, '*') == 1
+    # Instead of:
+    # xp.Sum(x[i, j] for j in FAC) == 1
     for i in CUST
 )
 prob.addConstraint(
@@ -236,6 +262,8 @@ prob.addConstraint(
 )
 prob.addConstraint(
     y.sum() == p
+    # Instead of:
+    # xp.Sum(y[j] for j in FAC) == p
 )
 
 # Solve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ select = ["F", "E", "W", "I", "D", "B", "UP", "FA"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403", "D212"]
 "setup.py" = ["D100"]
-"examples/*" = ["E501"]
+"examples/*" = ["I001", "E501"]
 "{docs,examples}/*" = ["E402"]
 "{docs,tests,examples}/**" = ["D"]
 

--- a/src/opti_extensions/__init__.py
+++ b/src/opti_extensions/__init__.py
@@ -9,7 +9,7 @@ A collection of custom data structures and user-friendly functions for mathemati
 modeling with docplex, gurobipy, and xpress.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 # Package functionality
 from ._index_sets import IndexSet1D, IndexSetND

--- a/src/opti_extensions/_var_dict_base.py
+++ b/src/opti_extensions/_var_dict_base.py
@@ -9,10 +9,57 @@ from __future__ import annotations
 from typing import Any, NoReturn, TypeVar, overload
 
 from ._dict_mixins import DefaultT, DictBaseMixin
-from ._index_sets import ElemT, IndexSetBase
+from ._index_sets import Elem1DT, ElemNDT, ElemT, IndexSetBase, IndexSetND
+from ._param_dicts import ParamDict1D, ParamDictND, ParamT
 
 VarT = TypeVar('VarT')
 ModelT = TypeVar('ModelT')
+
+
+def _validate_for_dot_1d(paramdict: ParamDict1D[Elem1DT, ParamT]) -> None:
+    """Validate ParamDict for dot product with VarDict1D.
+
+    Parameters
+    ----------
+    paramdict : ParamDict1D
+        ParamDict1D to be used for dot product.
+
+    Raises
+    ------
+    TypeError
+        If the paramdict is not as instance of ParamDict1D.
+    """
+    if not isinstance(paramdict, ParamDict1D):
+        raise TypeError('Dot product only allowed with ParamDict1D')
+
+
+def _validate_for_dot_Nd(
+    indexset: IndexSetND[ElemNDT], paramdict: ParamDictND[ElemNDT, ParamT]
+) -> None:
+    """Validate ParamDict for dot product with VarDictND.
+
+    Parameters
+    ----------
+    indexset : IndexSetND
+        Index-set of keys of VarDictND.
+    paramdict : ParamDictND
+        ParamDictND to be used for dot product.
+
+    Raises
+    ------
+    TypeError
+        If the paramdict is not as instance of ParamDictND.
+    ValueError
+        If the paramdict does not have tuple keys of same length as VarDictND.
+    """
+    if not isinstance(paramdict, ParamDictND):
+        raise TypeError(
+            'Dot product only allowed with ParamDictND (having tuple keys of same length as '
+            'VarDictND)'
+        )
+    else:
+        if paramdict._indexset._tuplelen != indexset._tuplelen:
+            raise ValueError('ParamDictND should have tuple keys of same length as VarDictND')
 
 
 class VarDictBase(dict[ElemT, VarT], DictBaseMixin[ElemT, VarT]):

--- a/src/opti_extensions/docplex/_var_dicts.py
+++ b/src/opti_extensions/docplex/_var_dicts.py
@@ -214,12 +214,12 @@ class VarDict1D(VarDictCore[Elem1DT, VarT], Dict1DMixin[Elem1DT, VarT]):
         """
         return super().get(key, 0)
 
-    def sum(self) -> LinearExpr | ZeroExpr:
+    def sum(self) -> LinearExpr:
         """Sum all variables in a linear expression.
 
         Returns
         -------
-        docplex.mp.linear.LinearExpr or docplex.mp.linear.ZeroExpr
+        docplex.mp.linear.LinearExpr
 
         Examples
         --------

--- a/src/opti_extensions/xpress/_var_dicts.py
+++ b/src/opti_extensions/xpress/_var_dicts.py
@@ -13,7 +13,8 @@ import xpress as xp
 
 from .._dict_mixins import Dict1DMixin, DictNDMixin
 from .._index_sets import Elem1DT, ElemNDT, ElemT, IndexSet1D, IndexSetBase, IndexSetND
-from .._var_dict_base import VarDictBase
+from .._param_dicts import ParamDict1D, ParamDictND, ParamT
+from .._var_dict_base import VarDictBase, _validate_for_dot_1d, _validate_for_dot_Nd
 
 VarT = TypeVar('VarT', bound=xp.var)
 
@@ -282,6 +283,78 @@ class VarDict1D(VarDictCore[Elem1DT, VarT], Dict1DMixin[Elem1DT, VarT]):
         """
         return xp.Sum(v**2 for v in self.values())
 
+    def dot(self, paramdict: ParamDict1D[Elem1DT, ParamT]) -> xp.expression:
+        """Sum the products of variables with corresponding coef from ParamDict1D, in an expression.
+
+        Assumes the coef to be zero if not found in the ParamDict1D.
+
+        Equivalent to::
+
+          xp.Sum(paramdict.get(k, 0) * v for k, v in vardict.items())
+
+        Parameters
+        ----------
+        paramdict : ParamDict1D
+            ParamDict1D to be used for dot product.
+
+        Returns
+        -------
+        xp.expression
+
+        Raises
+        ------
+        TypeError
+            If the paramdict is not as instance of ParamDict1D.
+
+        Notes
+        -----
+        This method is equivalent to using the matrix multiplication operator ``@``.
+
+        Both ``ParamDict1D @ VarDict1D`` and ``VarDict1D @ ParamDict1D`` will also produce the same
+        result.
+
+        Examples
+        --------
+        Create xpress problem:
+
+        >>> import xpress as xp
+        >>> import warnings
+        >>> warnings.filterwarnings('ignore', category=xp.LicenseWarning)
+
+        >>> prob = xp.problem()
+
+        Create index-set:
+
+        >>> nodes = IndexSet1D(['A', 'B', 'C'], name='node')
+
+        Add variables:
+
+        >>> from opti_extensions.xpress import addVariables
+        >>> node_select = addVariables(prob, nodes, name='node-select', vartype=xp.binary)
+
+        Define parameter:
+
+        >>> from opti_extensions import ParamDict1D
+        >>> fixed_cost = ParamDict1D({'A': 100, 'B': 200})
+
+        Compute dot product (three alternative ways):
+
+        >>> node_select.dot(fixed_cost)
+        100 * node-select(A) + 200 * node-select(B)
+
+        >>> fixed_cost @ node_select
+        100 * node-select(A) + 200 * node-select(B)
+
+        >>> node_select @ fixed_cost
+        100 * node-select(A) + 200 * node-select(B)
+        """
+        _validate_for_dot_1d(paramdict)
+        return xp.Sum(paramdict.get(k, 0) * v for k, v in self.items())
+
+    __matmul__ = dot
+
+    __rmatmul__ = dot
+
 
 class VarDictND(VarDictCore[ElemNDT, VarT], DictNDMixin[ElemNDT, VarT]):
     """Custom subclasses of `dict` to define xpress problem variables with N-dim tuple keys.
@@ -533,3 +606,78 @@ class VarDictND(VarDictCore[ElemNDT, VarT], DictNDMixin[ElemNDT, VarT]):
         if pattern:
             return xp.Sum(v**2 for v in self.subset_values(*pattern))
         return xp.Sum(v**2 for v in self.values())
+
+    def dot(self, paramdict: ParamDictND[ElemNDT, ParamT]) -> xp.expression:
+        """Sum the products of variables with corresponding coef from ParamDictND, in an expression.
+
+        Assumes the coef to be zero if not found in the ParamDictND.
+
+        Equivalent to::
+
+          xp.Sum(paramdict.get(k, 0) * v for k, v in vardict.items())
+
+        Parameters
+        ----------
+        paramdict : ParamDictND
+            ParamDictND to be used for dot product; should have tuple keys of same length as
+            VarDictND.
+
+        Returns
+        -------
+        xp.expression
+
+        Raises
+        ------
+        TypeError
+            If the paramdict is not as instance of ParamDictND.
+        ValueError
+            If the paramdict does not have tuple keys of same length as VarDictND.
+
+        Notes
+        -----
+        This method is equivalent to using the matrix multiplication operator ``@``.
+
+        Both ``ParamDictND @ VarDictND`` and ``VarDictND @ ParamDictND`` will also produce the same
+        result.
+
+        Examples
+        --------
+        Create xpress problem:
+
+        >>> import xpress as xp
+        >>> import warnings
+        >>> warnings.filterwarnings('ignore', category=xp.LicenseWarning)
+
+        >>> prob = xp.problem()
+
+        Create index-set:
+
+        >>> arcs = IndexSetND([('A', 'B'), ('B', 'C'), ('C', 'B')], names=['ori', 'des'])
+
+        Add variables:
+
+        >>> from opti_extensions.xpress import addVariables
+        >>> arc_flow = addVariables(prob, arcs, name='arc-flow', ub=10, vartype=xp.continuous)
+
+        Define parameter:
+
+        >>> from opti_extensions import ParamDictND
+        >>> cost = ParamDictND({('A', 'B'): 10, ('B', 'C'): 20})
+
+        Compute dot product (three alternative ways):
+
+        >>> arc_flow.dot(cost)
+        10 * arc-flow(('A', 'B')) + 20 * arc-flow(('B', 'C'))
+
+        >>> cost @ arc_flow
+        10 * arc-flow(('A', 'B')) + 20 * arc-flow(('B', 'C'))
+
+        >>> arc_flow @ cost
+        10 * arc-flow(('A', 'B')) + 20 * arc-flow(('B', 'C'))
+        """
+        _validate_for_dot_Nd(self._indexset, paramdict)
+        return xp.Sum(paramdict.get(k, 0) * v for k, v in self.items())
+
+    __matmul__ = dot
+
+    __rmatmul__ = dot

--- a/tests/functional_tests/docplex_diet_test.py
+++ b/tests/functional_tests/docplex_diet_test.py
@@ -142,7 +142,7 @@ def test_diet():
     ##### Set objective
 
     # Minimize the total cost of the diet
-    model.minimize(model.sum(cost[j] * buy[j] for j in FOOD))
+    model.minimize(cost @ buy)
 
     ##### Add constraints
 

--- a/tests/functional_tests/docplex_multicommodity_test.py
+++ b/tests/functional_tests/docplex_multicommodity_test.py
@@ -140,10 +140,7 @@ def test_multicommodity():
     ##### Set objective
 
     # Minimize the total shipping cost
-    model.minimize(
-        model.sum(vcost[i, j, p] * trans[i, j, p] for i in ORIG for j in DEST for p in PROD)
-        + model.sum(fcost[i, j] * use[i, j] for i in ORIG for j in DEST)
-    )
+    model.minimize(vcost @ trans + fcost @ use)
 
     ##### Add constraints
 

--- a/tests/functional_tests/gurobipy_diet_test.py
+++ b/tests/functional_tests/gurobipy_diet_test.py
@@ -140,7 +140,7 @@ def test_diet():
     ##### Set objective
 
     # Minimize the total cost of the diet
-    model.setObjective(quicksum(cost[j] * buy[j] for j in FOOD), GRB.MINIMIZE)
+    model.setObjective(cost @ buy, GRB.MINIMIZE)
 
     ##### Add constraints
 

--- a/tests/functional_tests/gurobipy_multicommodity_test.py
+++ b/tests/functional_tests/gurobipy_multicommodity_test.py
@@ -10,7 +10,7 @@ https://github.com/ampl/colab.ampl.com/blob/master/ampl-book/multmip1.ipynb
 """
 
 import pandas as pd
-from gurobipy import GRB, Model, quicksum
+from gurobipy import GRB, Model
 
 from opti_extensions import IndexSetND
 from opti_extensions.gurobipy import addVars
@@ -141,8 +141,7 @@ def test_multicommodity():
 
     # Minimize the total shipping cost
     model.setObjective(
-        quicksum(vcost[i, j, p] * trans[i, j, p] for i in ORIG for j in DEST for p in PROD)
-        + quicksum(fcost[i, j] * use[i, j] for i in ORIG for j in DEST),
+        vcost @ trans + fcost @ use,
         GRB.MINIMIZE,
     )
 

--- a/tests/functional_tests/xpress_diet_test.py
+++ b/tests/functional_tests/xpress_diet_test.py
@@ -147,7 +147,7 @@ def test_diet():
     ##### Set objective
 
     # Minimize the total cost of the diet
-    prob.setObjective(xp.Sum(cost[j] * buy[j] for j in FOOD), sense=xp.minimize)
+    prob.setObjective(cost @ buy, sense=xp.minimize)
 
     ##### Add constraints
 

--- a/tests/functional_tests/xpress_multicommodity_test.py
+++ b/tests/functional_tests/xpress_multicommodity_test.py
@@ -148,8 +148,7 @@ def test_multicommodity():
 
     # Minimize the total shipping cost
     prob.setObjective(
-        xp.Sum(vcost[i, j, p] * trans[i, j, p] for i in ORIG for j in DEST for p in PROD)
-        + xp.Sum(fcost[i, j] * use[i, j] for i in ORIG for j in DEST),
+        vcost @ trans + fcost @ use,
         sense=xp.minimize,
     )
 

--- a/tests/unit_tests/docplex_var_dicts_funcs/custom_methods_test.py
+++ b/tests/unit_tests/docplex_var_dicts_funcs/custom_methods_test.py
@@ -66,7 +66,8 @@ def test_vardictNd_lookup_valerr(mdl, key):
 )
 def test_vardict_sum_pass(mdl, indexset):
     v = add_variables(mdl, indexset, 'C', name='VAL')
-    assert v.sum().to_string() == mdl.sum(x for x in v.values()).to_string()
+    assert v.sum().to_string() == mdl.sum(v.values()).to_string()
+    assert v.sum_squares().to_string() == mdl.sumsq(v.values()).to_string()
 
 
 @pytest.mark.parametrize(
@@ -91,6 +92,10 @@ def test_vardictNd_sum_partial_pass(mdl, indexset, pattern):
         v.sum(*pattern).to_string()
         == mdl.sum(var for idx, var in v.items() if _match(idx, pattern)).to_string()
     )
+    assert (
+        v.sum_squares(*pattern).to_string()
+        == mdl.sumsq(var for idx, var in v.items() if _match(idx, pattern)).to_string()
+    )
 
 
 @pytest.mark.parametrize(
@@ -105,3 +110,5 @@ def test_vardictNd_sum_partial_valerr(mdl, indexset, pattern):
     v = add_variables(mdl, indexset, 'C', name='VAL')
     with pytest.raises(ValueError):
         v.sum(*pattern)
+    with pytest.raises(ValueError):
+        v.sum_squares(*pattern)

--- a/tests/unit_tests/docplex_var_dicts_funcs/custom_methods_test.py
+++ b/tests/unit_tests/docplex_var_dicts_funcs/custom_methods_test.py
@@ -6,7 +6,7 @@
 
 import pytest
 
-from opti_extensions import IndexSet1D, IndexSetND
+from opti_extensions import IndexSet1D, IndexSetND, ParamDict1D, ParamDictND
 from opti_extensions.docplex import add_variables
 
 
@@ -112,3 +112,100 @@ def test_vardictNd_sum_partial_valerr(mdl, indexset, pattern):
         v.sum(*pattern)
     with pytest.raises(ValueError):
         v.sum_squares(*pattern)
+
+
+@pytest.mark.parametrize(
+    'indexset, paramdict',
+    [
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'A': 1, 'B': 2, 'C': 3})),
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'A': 1, 'B': 2})),
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'A': 1, 'B': 2, 'X': 9})),
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'X': 9})),
+        (IndexSet1D(range(3)), ParamDict1D({0: 0, 1: 10, 2: 20})),
+        (IndexSet1D(range(3)), ParamDict1D({0: 0, 1: 10})),
+        (IndexSet1D(range(3)), ParamDict1D({0: 0, 1: 10, 9: 90})),
+        (IndexSet1D(range(3)), ParamDict1D({9: 90})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1, (9, 9): 9})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(9, 9): 9})),
+        (
+            IndexSetND(['A', 'B'], range(2)),
+            ParamDictND({('A', 0): 6, ('B', 0): 7, ('A', 1): 8, ('B', 1): 9}),
+        ),
+        (IndexSetND(['A', 'B'], range(2)), ParamDictND({('A', 0): 6, ('B', 0): 7, ('A', 1): 8})),
+        (
+            IndexSetND(['A', 'B'], range(2)),
+            ParamDictND({('A', 0): 6, ('B', 0): 7, ('A', 1): 8, ('X', 9): 9}),
+        ),
+        (IndexSetND(['A', 'B'], range(2)), ParamDictND({('X', 9): 9})),
+    ],
+)
+def test_vardict_dot_pass(mdl, indexset, paramdict):
+    vardict = add_variables(mdl, indexset, 'C', name='VAL')
+    res = mdl.sum(paramdict.get(k, 0) * v for k, v in vardict.items())
+
+    assert vardict.dot(paramdict).to_string() == res.to_string()
+    assert (paramdict @ vardict).to_string() == res.to_string()
+    assert (vardict @ paramdict).to_string() == res.to_string()
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2}),
+        {(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2},
+        {'A': 1, 'B': 2, 'X': 9},
+        1,
+        1.0,
+        'ABC',
+    ],
+)
+def test_vardict1D_typ_err(mdl, other):
+    vardict = add_variables(mdl, IndexSet1D(['A', 'B', 'C']), 'C', name='VAL')
+    with pytest.raises(TypeError):
+        vardict.dot(other)
+    with pytest.raises(TypeError):
+        other @ vardict
+    with pytest.raises(TypeError):
+        vardict @ other
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        ParamDict1D({0: 0, 1: 10, 2: 20}),
+        {(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2},
+        {'A': 1, 'B': 2, 'X': 9},
+        1,
+        1.0,
+        'ABC',
+        (0, 10, 20),
+        [0, 10, 20],
+    ],
+)
+def test_vardictND_typ_err(mdl, other):
+    vardict = add_variables(mdl, IndexSetND(['A', 'B', 'C'], range(3)), 'C', name='VAL')
+    with pytest.raises(TypeError):
+        vardict.dot(other)
+    with pytest.raises(TypeError):
+        other @ vardict
+    with pytest.raises(TypeError):
+        vardict @ other
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        ParamDictND({('A', 0): 0, ('A', 1): 1, ('B', 0): 1, ('B', 1): 2}),
+        ParamDictND({('A', 0, 0, 0): 0, ('B', 1, 0, 0): 1, ('A', 0, 0, 1): 1, ('B', 1, 0, 1): 2}),
+    ],
+)
+def test_vardictND_val_err(mdl, other):
+    vardict = add_variables(mdl, IndexSetND(['A', 'B'], range(3), range(3)), 'C', name='VAL')
+    with pytest.raises(ValueError):
+        vardict.dot(other)
+    with pytest.raises(ValueError):
+        other @ vardict
+    with pytest.raises(ValueError):
+        vardict @ other

--- a/tests/unit_tests/gurobipy_var_dicts_funcs/custom_methods_test.py
+++ b/tests/unit_tests/gurobipy_var_dicts_funcs/custom_methods_test.py
@@ -69,6 +69,7 @@ def test_vardict_sum_pass(mdl, indexset):
     v = addVars(mdl, indexset, vtype=GRB.CONTINUOUS, name='VAL')
     mdl.update()
     assert str(v.sum()) == str(quicksum(x for x in v.values()))
+    assert str(v.sum_squares()) == str(quicksum(x**2 for x in v.values()))
 
 
 @pytest.mark.parametrize(
@@ -93,6 +94,9 @@ def test_vardictNd_sum_partial_pass(mdl, indexset, pattern):
     assert str(v.sum(*pattern)) == str(
         quicksum(var for idx, var in v.items() if _match(idx, pattern))
     )
+    assert str(v.sum_squares(*pattern)) == str(
+        quicksum(var**2 for idx, var in v.items() if _match(idx, pattern))
+    )
 
 
 @pytest.mark.parametrize(
@@ -107,3 +111,5 @@ def test_vardictNd_sum_partial_valerr(mdl, indexset, pattern):
     v = addVars(mdl, indexset, vtype=GRB.CONTINUOUS, name='VAL')
     with pytest.raises(ValueError):
         v.sum(*pattern)
+    with pytest.raises(ValueError):
+        v.sum_squares(*pattern)

--- a/tests/unit_tests/gurobipy_var_dicts_funcs/custom_methods_test.py
+++ b/tests/unit_tests/gurobipy_var_dicts_funcs/custom_methods_test.py
@@ -7,7 +7,7 @@
 import pytest
 from gurobipy import GRB, quicksum
 
-from opti_extensions import IndexSet1D, IndexSetND
+from opti_extensions import IndexSet1D, IndexSetND, ParamDict1D, ParamDictND
 from opti_extensions.gurobipy import addVars
 
 
@@ -113,3 +113,102 @@ def test_vardictNd_sum_partial_valerr(mdl, indexset, pattern):
         v.sum(*pattern)
     with pytest.raises(ValueError):
         v.sum_squares(*pattern)
+
+
+@pytest.mark.parametrize(
+    'indexset, paramdict',
+    [
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'A': 1, 'B': 2, 'C': 3})),
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'A': 1, 'B': 2})),
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'A': 1, 'B': 2, 'X': 9})),
+        (IndexSet1D(['A', 'B', 'C']), ParamDict1D({'X': 9})),
+        (IndexSet1D(range(3)), ParamDict1D({0: 0, 1: 10, 2: 20})),
+        (IndexSet1D(range(3)), ParamDict1D({0: 0, 1: 10})),
+        (IndexSet1D(range(3)), ParamDict1D({0: 0, 1: 10, 9: 90})),
+        (IndexSet1D(range(3)), ParamDict1D({9: 90})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1, (9, 9): 9})),
+        (IndexSetND(range(2), range(2)), ParamDictND({(9, 9): 9})),
+        (
+            IndexSetND(['A', 'B'], range(2)),
+            ParamDictND({('A', 0): 6, ('B', 0): 7, ('A', 1): 8, ('B', 1): 9}),
+        ),
+        (IndexSetND(['A', 'B'], range(2)), ParamDictND({('A', 0): 6, ('B', 0): 7, ('A', 1): 8})),
+        (
+            IndexSetND(['A', 'B'], range(2)),
+            ParamDictND({('A', 0): 6, ('B', 0): 7, ('A', 1): 8, ('X', 9): 9}),
+        ),
+        (IndexSetND(['A', 'B'], range(2)), ParamDictND({('X', 9): 9})),
+    ],
+)
+def test_vardict_dot_pass(mdl, indexset, paramdict):
+    vardict = addVars(mdl, indexset, vtype=GRB.CONTINUOUS, name='VAL')
+    res = quicksum(paramdict.get(k, 0) * v for k, v in vardict.items())
+
+    assert str(vardict.dot(paramdict)) == str(res)
+    assert str(paramdict @ vardict) == str(res)
+    assert str(vardict @ paramdict) == str(res)
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        ParamDictND({(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2}),
+        {(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2},
+        {'A': 1, 'B': 2, 'X': 9},
+        1,
+        1.0,
+        'ABC',
+    ],
+)
+def test_vardict1D_typ_err(mdl, other):
+    vardict = addVars(mdl, IndexSet1D(['A', 'B', 'C']), vtype=GRB.CONTINUOUS, name='VAL')
+    with pytest.raises(TypeError):
+        vardict.dot(other)
+    with pytest.raises(TypeError):
+        other @ vardict
+    with pytest.raises(TypeError):
+        vardict @ other
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        ParamDict1D({0: 0, 1: 10, 2: 20}),
+        {(0, 0): 0, (0, 1): 1, (1, 0): 1, (1, 1): 2},
+        {'A': 1, 'B': 2, 'X': 9},
+        1,
+        1.0,
+        'ABC',
+        (0, 10, 20),
+        [0, 10, 20],
+    ],
+)
+def test_vardictND_typ_err(mdl, other):
+    vardict = addVars(mdl, IndexSetND(['A', 'B'], range(3)), vtype=GRB.CONTINUOUS, name='VAL')
+    with pytest.raises(TypeError):
+        vardict.dot(other)
+    with pytest.raises(TypeError):
+        other @ vardict
+    with pytest.raises(TypeError):
+        vardict @ other
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        ParamDictND({('A', 0): 0, ('A', 1): 1, ('B', 0): 1, ('B', 1): 2}),
+        ParamDictND({('A', 0, 0, 0): 0, ('B', 1, 0, 0): 1, ('A', 0, 0, 1): 1, ('B', 1, 0, 1): 2}),
+    ],
+)
+def test_vardictND_val_err(mdl, other):
+    vardict = addVars(
+        mdl, IndexSetND(['A', 'B'], range(3), range(3)), vtype=GRB.CONTINUOUS, name='VAL'
+    )
+    with pytest.raises(ValueError):
+        vardict.dot(other)
+    with pytest.raises(ValueError):
+        other @ vardict
+    with pytest.raises(ValueError):
+        vardict @ other

--- a/tests/unit_tests/xpress_var_dicts_funcs/custom_methods_test.py
+++ b/tests/unit_tests/xpress_var_dicts_funcs/custom_methods_test.py
@@ -68,6 +68,7 @@ def test_vardictNd_lookup_valerr(prob, key):
 def test_vardict_sum_pass(prob, indexset):
     v = addVariables(prob, indexset, vartype=xp.continuous, name='')
     assert str(v.sum()) == str(xp.Sum(x for x in v.values()))
+    assert str(v.sum_squares()) == str(xp.Sum(x**2 for x in v.values()))
 
 
 @pytest.mark.parametrize(
@@ -91,6 +92,9 @@ def test_vardictNd_sum_partial_pass(prob, indexset, pattern):
     assert str(v.sum(*pattern)) == str(
         xp.Sum(var for idx, var in v.items() if _match(idx, pattern))
     )
+    assert str(v.sum_squares(*pattern)) == str(
+        xp.Sum(var**2 for idx, var in v.items() if _match(idx, pattern))
+    )
 
 
 @pytest.mark.parametrize(
@@ -105,3 +109,5 @@ def test_vardictNd_sum_partial_valerr(prob, indexset, pattern):
     v = addVariables(prob, indexset, vartype=xp.continuous, name='')
     with pytest.raises(ValueError):
         v.sum(*pattern)
+    with pytest.raises(ValueError):
+        v.sum_squares(*pattern)


### PR DESCRIPTION
## Features
* Add `sum_squares` method for VarDicts with tests, docs, examples
* Add `dot` method & `@` operator for VarDicts with tests, docs, examples

## Fixes
* Refine the return type of DOcplex `VarDict1D.sum`

## Docs
* Add equivalent conventional/default syntax in model build examples
* Fix unordered import statement in tutorials

## Dev
* Update linter id ruff-check in pre-commit config