### PR TITLE
Add testing support for Xpress 9.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,12 +25,14 @@ jobs:
           MAIN_SHA=$(git rev-parse origin/main)
           echo "main_sha=$MAIN_SHA" >> $GITHUB_ENV
 
-      - name: Check for changed python files
+      - name: Check for changed python files or pyproject.toml
         id: changed-py-files
         uses: tj-actions/changed-files@v46
         with:
           base_sha: ${{ env.main_sha }}
-          files: '**/*.py'
+          files: |
+            '**/*.py'
+            'pyproject.toml'
 
     outputs:
       any_changed: ${{ steps.changed-py-files.outputs.any_changed }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,8 +31,8 @@ jobs:
         with:
           base_sha: ${{ env.main_sha }}
           files: |
-            '**/*.py'
-            'pyproject.toml'
+            **/*.py
+            pyproject.toml
 
     outputs:
       any_changed: ${{ steps.changed-py-files.outputs.any_changed }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Features
 * **Specialized data structures**: For defining index-sets, parameters, and decision variables enabling concise and high-performance algebraic modeling — compatible across different solver APIs.
 * **Easy access to additional CPLEX functionality**: Like [tuning tool](https://www.ibm.com/docs/en/icos/latest?topic=programmingconsiderations-tuning-tool), [runseeds](https://www.ibm.com/docs/en/icos/latest?topic=cplex-evaluating-variability), [displaying problem statistics](https://www.ibm.com/docs/en/icos/latest?topic=problem-displaying-statistics), and [displaying solution quality statistics](https://www.ibm.com/docs/en/icos/latest?topic=cplex-evaluating-solution-quality) — not directly available in DOcplex.
 * **Type-complete interface**: Enables static type checking and intelligent auto-completion suggestions with modern IDEs — reducing type errors and improving development speed.
-* **Robust codebase**: 100% coverage spanning 2750+ test cases and fully type-checked with mypy under [strict mode](https://mypy.readthedocs.io/en/stable/getting_started.html#strict-mode-and-configuration).
+* **Robust codebase**: 100% coverage spanning 2750+ test cases and fully type-checked with mypy under [strict mode](https://mypy.readthedocs.io/en/stable/getting_started.html#strict-mode-and-configuration). Tested with:
+    * CPLEX versions: 20.1.0, 22.1.0, 22.1.1, 22.1.2
+    * Gurobi versions: 11.0, 12.0
+     (most likely works with 10.0 but [cannot test](https://support.gurobi.com/hc/en-us/articles/19487474933521-How-do-I-resolve-the-error-License-expired-2024-10-28) with the size-limited license provided with gurobipy distributed via PyPI)
+    * Xpress versions: 9.4, 9.5, 9.6, 9.7
 
 Links
 -----
@@ -39,4 +43,4 @@ Dev dependencies can be installed with the pip [extras](https://packaging.python
 License
 -------
 
-*opti-extensions* is an open-source project developed by [Samarth Mistry](https://www.linkedin.com/in/samarthmistry) and released under the Apache 2.0 License. See the [LICENSE](https://github.com/samarthmistry/opti-extensions/blob/main/LICENSE) and [NOTICE](https://github.com/samarthmistry/opti-extensions/blob/main/NOTICE) for more details.
+opti-extensions is an open-source project developed by [Samarth Mistry](https://www.linkedin.com/in/samarthmistry) and released under the Apache 2.0 License. See the [LICENSE](https://github.com/samarthmistry/opti-extensions/blob/main/LICENSE) and [NOTICE](https://github.com/samarthmistry/opti-extensions/blob/main/NOTICE) for more details.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,7 +26,15 @@ Features
   improving development speed.
 * **Robust codebase**: 100% coverage spanning 2750+ test cases and fully
   type-checked with mypy under `strict mode <https://mypy.readthedocs.io/en/
-  stable/getting_started.html#strict-mode-and-configuration>`_.
+  stable/getting_started.html#strict-mode-and-configuration>`_. Tested with:
+
+  * CPLEX versions: 20.1.0, 22.1.0, 22.1.1, 22.1.2
+  * Gurobi versions: 11.0, 12.0
+    (most likely works with 10.0 but `cannot test <https://support.gurobi.
+    com/hc/en-us/articles/19487474933521-How-do-I-resolve-the-error-License
+    -expired-2024-10-28>`_ with the size-limited license provided with
+    gurobipy distributed via PyPI)
+  * Xpress versions: 9.4, 9.5, 9.6, 9.7
 
 Documentation
 =============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ env_list = [
     "xprs94",
     "xprs95",
     "xprs96",
+    "xprs97",
 ]
 
 [tool.tox.gh.python]
@@ -247,6 +248,7 @@ env_list = [
     "xprs94",
     "xprs95",
     "xprs96",
+    "xprs97",
 ]
 "3.11" = ["py311"]
 "3.12" = ["py312"]
@@ -486,6 +488,23 @@ commands = [
 description = "Run unit tests for model functions against Xpress 9.6"
 base_python = ["3.10"]
 deps = ["xpress>=9.6,<9.7"]
+extras = ["tests"]
+commands = [
+    [
+        "pytest",
+        "--basetemp={env_tmp_dir}",
+        "--no-cov",
+        "tests{/}unit_tests{/}xpress_var_dicts_funcs{/}",
+        "tests{/}functional_tests{/}xpress_diet_test.py",
+        "tests{/}functional_tests{/}xpress_multicommodity_test.py",
+        { replace = "posargs", extend = true },
+    ],
+]
+
+[tool.tox.env.xprs97]
+description = "Run unit tests for model functions against Xpress 9.7"
+base_python = ["3.10"]
+deps = ["xpress>=9.7,<9.8"]
 extras = ["tests"]
 commands = [
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,7 @@ commands = [
 # Since CPLEX runtime is not supported beyond python 3.12, we skip all runtime-based tests
 # i.e., anything that invokes solve
 description = "Run doctests, unit tests ex. model functions, and typing tests"
-deps = ["docplex>=2.25.236", "gurobipy>=11.0.0", "xpress>=9.2.0"]
+deps = ["docplex>=2.25.236", "gurobipy>=11", "xpress>=9.4"]
 extras = ["tests"]
 commands = [
     [


### PR DESCRIPTION
## Docs
* List the CPLEX, Gurobi, and Xpress solver versions that the package is tested with

## Dev
* Testing: Include Xpress 9.7 in the tox test suite